### PR TITLE
Concurrent batch

### DIFF
--- a/munki_manifest_generator/azstorage/az_storage_actions.py
+++ b/munki_manifest_generator/azstorage/az_storage_actions.py
@@ -12,9 +12,10 @@ from munki_manifest_generator.azstorage.az_storage_clients import (
     az_container_client,
 )
 from munki_manifest_generator.get_device_catalogs import get_device_catalogs
+from munki_manifest_generator.logger import logger
 
 
-def get_current_manifest_blobs(connection_string, container_name):
+def get_current_manifest_blobs(connection_string: str, container_name: str) -> list:
     """Returns a list of the blob names in the container."""
     CURRENT_MANIFESTS = []
     try:
@@ -28,12 +29,12 @@ def get_current_manifest_blobs(connection_string, container_name):
             CURRENT_MANIFESTS.append(blob_name)
 
     except Exception as ex:
-        print("Error: " + str(ex))
+        logger.error("Error: " + str(ex))
 
     return CURRENT_MANIFESTS
 
 
-def create_manifest_blob(connection_string, container_name, file_name, device, test):
+def create_manifest_blob(connection_string: str, container_name: str, file_name: str, device: dict, test: bool):
     """Creates a blob with the given file name and data."""
     try:
         local_path = "./"
@@ -46,32 +47,37 @@ def create_manifest_blob(connection_string, container_name, file_name, device, t
 
         if not test:
             with open(upload_file_path, "rb") as data:
-                blob_client.upload_blob(data)
+                blob_client.upload_blob(data, overwrite=True)
         os.remove(upload_file_path)
 
     except Exception as ex:
-        print("Error: " + str(ex))
+        logger.error("Error: " + str(ex))
 
 
 def delete_manifest_blob(
-    connection_string, container_name, groups, serial_numbers, safe_manifest, test
+    connection_string: str,
+    container_name: str,
+    groups: list,
+    serial_numbers: list,
+    safe_manifest: str,
+    test: bool,
+    current_manifest_list: list,
 ):
     """Deletes blobs in the container if the device is not in Intune."""
+
     try:
-        # Get the list of blobs in the container
-        current_manifests = get_current_manifest_blobs(
-            connection_string, container_name
-        )
         # Get list of group names
-        groups = [val for list in groups for key, val in list.items() if key == "name"]
+        groups = [val for val in groups for key, val in val.items() if key == "name"]
         delete_manifests = []
         if safe_manifest:
             do_not_delete_manifest = safe_manifest.lower().split(",")
         else:
             do_not_delete_manifest = []
 
-        for manifest in current_manifests:
-            # If the manifest is not in the list of serial numbers, is not in the list of groups, is not site_defualt, and is not in the list of safe manifests, add it to the list of manifests to delete
+        for manifest in current_manifest_list:
+            # If the manifest is not in the list of serial numbers,
+            # is not in the list of groups, is not site_default,
+            # and is not in the list of safe manifests, add it to the list of manifests to delete
             if (
                 (manifest not in serial_numbers)
                 and (manifest not in groups)
@@ -80,22 +86,53 @@ def delete_manifest_blob(
             ):
                 delete_manifests.append(manifest)
 
-                blob_client = az_blob_client(
-                    connection_string, container_name, manifest
-                )
+                blob_client = az_blob_client(connection_string, container_name, manifest)
                 if not test:
                     blob_client.delete_blob()
 
         if delete_manifests:
-            print(("{0:-^{1}}".format(str(len(delete_manifests)) + " deleted manifests", 90)))
-            print("\n".join(delete_manifests))
+            logger.info(("{0:-^{1}}".format(str(len(delete_manifests)) + " deleted manifests", 90)))
+            logger.info(", ".join(delete_manifests))
+            logger.info("-" * 90)
 
     except Exception as ex:
-        print("Error: " + str(ex))
+        logger.error("Error: " + str(ex))
 
 
-def get_current_device_manifest(connection_string, container_name, serial_number):
+def update_current_upn(connection_string: str, container_name: str, serial_number: str, upn: str, old_user: str, test: bool):
+    """Updates the UPN in the manifest for the given serial number."""
+
+    try:
+        logger.info("[%s] Updating user to %s from %s", serial_number, upn, old_user)
+        local_path = "./"
+        download_file_path = os.path.join(local_path, serial_number)
+        blob_client = az_blob_client(connection_string, container_name, serial_number)
+
+        with open(download_file_path, "wb") as _f:
+            blob_data = blob_client.download_blob()
+            data = blob_data.readall()
+            plist_data = plistlib.loads(data)
+
+        plist_data["user"] = upn
+
+        with open(download_file_path, "wb") as _f:
+            plistlib.dump(plist_data, _f)
+
+        blob_client = az_blob_client(connection_string, container_name, serial_number)
+
+        if not test:
+            with open(download_file_path, "rb") as data:
+                blob_client.upload_blob(data, overwrite=True)
+
+        os.remove(download_file_path)
+
+    except Exception as ex:
+        logger.error("Error: " + str(ex))
+
+
+def get_current_device_manifest(connection_string: str, container_name: str, serial_number: str) -> dict:
     """Returns the current manifest for the given serial number."""
+
     try:
         local_path = "./"
         download_file_path = os.path.join(local_path, serial_number)
@@ -111,27 +148,25 @@ def get_current_device_manifest(connection_string, container_name, serial_number
         return plist_data
 
     except Exception as ex:
-        print("Error: " + str(ex))
+        logger.error("Error: " + str(ex))
 
 
 def update_manifest_blob(
-    connection_string,
-    container_name,
-    file_name,
-    device_manifest,
-    group_membership,
-    groups,
-    test,
-    default_catalog,
-):
+    connection_string: str,
+    container_name: str,
+    file_name: str,
+    device_manifest: dict,
+    group_membership: list,
+    groups: list,
+    test: bool,
+    default_catalog: str,
+    current_manifest_list: list,
+) -> list:
     """Updates the manifest with the given file name and data."""
+
     try:
         local_path = "./"
         download_file_path = os.path.join(local_path, file_name)
-
-        current_manifests = get_current_manifest_blobs(
-            connection_string, container_name
-        )
 
         blob_client = az_blob_client(connection_string, container_name, file_name)
 
@@ -144,9 +179,7 @@ def update_manifest_blob(
             remove_manifests = []
 
             # Get updates to device catalogs
-            add_catalog = get_device_catalogs(
-                groups, device_manifest, default_catalog, add_catalogs=True
-            )
+            add_catalog = get_device_catalogs(groups, device_manifest, default_catalog, add_catalogs=True)
             # If updated catalogs are not equal to the current catalogs, update the manifest
             if add_catalog != device_manifest.catalogs:
                 device_manifest.catalogs = add_catalog
@@ -158,49 +191,47 @@ def update_manifest_blob(
                 if manifest not in plist_data["included_manifests"]:
                     add_manifests.append(manifest)
                 # If manifest is in the current manifest list, remove it from the list of manifests to add
-                if manifest not in current_manifests:
-                    print("Manifest " + manifest + " not found, skipping")
-                    # If the manifest not in the current manifest list, but in the device manifest list, add it to the list of manifests to remove
+                if manifest not in current_manifest_list:
+                    logger.info("[%s] Manifest %s not found, skipping", file_name, manifest)
+                    # If the manifest not in the current manifest list,
+                    # but in the device manifest list, add it to the list of manifests to remove
                     if manifest in device_manifest.included_manifests:
                         device_manifest.included_manifests.remove(manifest)
                         remove_manifests.append(manifest)
-                    # If the manifest is not in the current manifest list, but in the add manifest list, remove it from the add manifest list
+                    # If the manifest is not in the current manifest list, but in the add manifest list,
+                    # remove it from the add manifest list
                     if manifest in add_manifests:
                         add_manifests.remove(manifest)
 
             # Check if the device is a member of any AAD group based included manifest but not the AAD group
             for group_manifest in plist_data["included_manifests"]:
-                # If the AAD group based manifest is not in the device's membership list, add it to the list of manifests to remove
-                if (group_manifest not in group_membership) and (
-                    group_manifest != "site_default"
-                ):
+                # If the AAD group based manifest is not in the device's membership list,
+                # add it to the list of manifests to remove
+                if (group_manifest not in group_membership) and (group_manifest != "site_default"):
                     remove_manifests.append(group_manifest)
 
             # If there are manifests to remove, remove them
             if remove_manifests:
                 for manifest in remove_manifests:
                     plist_data["included_manifests"].remove(manifest)
-                    device_manifest.included_manifests = plist_data[
-                        "included_manifests"
-                    ]
+                    device_manifest.included_manifests = plist_data["included_manifests"]
 
             # Check if there are catalogs to remove
-            remove_catalogs = get_device_catalogs(
-                groups, device_manifest, default_catalog, remove_catalogs=True
-            )
+            remove_catalogs = get_device_catalogs(groups, device_manifest, default_catalog, remove_catalogs=True)
 
             plistlib.dump(device_manifest.__dict__, _f)
 
         if add_manifests or add_catalogs or remove_manifests or remove_catalogs:
-            print("Manifests or catalogs changed, updating")
+            # logger.info("[%s] Manifests or catalogs changed, updating..." % file_name)
             if add_manifests:
-                print("Manifests: \n" + " - " + "\n - ".join(add_manifests))
+                logger.info("[%s] " % file_name + "New manifest list: " + ", ".join(add_manifests))
             if add_catalogs:
-                print("Catalogs: \n" + " - " + "\n - ".join(add_catalog))
+                logger.info("[%s] " % file_name + "New catalog list: " + ", ".join(add_catalog))
             if remove_manifests:
-                print("Manifests removed: \n" + " - " + "\n - ".join(remove_manifests))
+                logger.info("[%s] " % file_name + "Manifests removed: " + ", ".join(remove_manifests))
             if remove_catalogs:
-                print("Catalogs removed: \n" + " - " + "\n - ".join(remove_catalogs))
+                logger.info("[%s] " % file_name + "Catalogs removed: " + ", ".join(remove_catalogs))
+
             if not test:
                 with open(download_file_path, "rb") as data:
                     blob_client.upload_blob(data, overwrite=True)
@@ -208,4 +239,4 @@ def update_manifest_blob(
         os.remove(download_file_path)
 
     except Exception as ex:
-        print("Error: " + str(ex))
+        logger.error("Error: " + str(ex))

--- a/munki_manifest_generator/azstorage/az_storage_clients.py
+++ b/munki_manifest_generator/azstorage/az_storage_clients.py
@@ -4,37 +4,30 @@
 This module is used to create clients for Azure Storage.
 """
 
-from azure.storage.blob import BlobServiceClient
+from azure.storage.blob import BlobServiceClient, ContainerClient
+from munki_manifest_generator.logger import logger
 
 
-def az_container_client(connection_string, container_name):
+def az_container_client(connection_string: str, container_name: str) -> ContainerClient:
     """Create a container client to get the list of files in the container."""
     try:
-        blob_source_service_client = BlobServiceClient.from_connection_string(
-            connection_string
-        )
-        container_client = blob_source_service_client.get_container_client(
-            container_name
-        )
+        blob_source_service_client = BlobServiceClient.from_connection_string(connection_string)
+        container_client = blob_source_service_client.get_container_client(container_name)
 
         return container_client
 
     except Exception as ex:
-        print("Error: " + str(ex))
+        logger.error("Error: " + str(ex))
 
 
-def az_blob_client(connection_string, container_name, file_name):
+def az_blob_client(connection_string: str, container_name: str, file_name: str) -> BlobServiceClient:
     """Create a blob client to get the file from the container."""
     try:
-        blob_service_client = BlobServiceClient.from_connection_string(
-            connection_string
-        )
+        blob_service_client = BlobServiceClient.from_connection_string(connection_string)
 
-        blob_client = blob_service_client.get_blob_client(
-            container=container_name + "/manifests", blob=file_name
-        )
+        blob_client = blob_service_client.get_blob_client(container=container_name + "/manifests", blob=file_name)
 
         return blob_client
 
     except Exception as ex:
-        print("Error: " + str(ex))
+        logger.error("Error: " + str(ex))

--- a/munki_manifest_generator/get_device_catalogs.py
+++ b/munki_manifest_generator/get_device_catalogs.py
@@ -7,17 +7,10 @@ This module is used to get the catalogs that should be added or removed from a d
 from collections import defaultdict
 
 
-def get_device_catalogs(
-    groups, device_manifest, default_catalog, add_catalogs=False, remove_catalogs=False
-):
+def get_device_catalogs(groups, device_manifest, default_catalog, add_catalogs=False, remove_catalogs=False) -> list:
+    """Get the catalogs that should be added or removed from a device."""
 
-    GROUP_CATALOGS = [
-        val
-        for list in groups
-        for key, val in list.items()
-        if "catalog" in key
-        if val is not None
-    ]
+    GROUP_CATALOGS = [val for list in groups for key, val in list.items() if "catalog" in key if val is not None]
 
     if add_catalogs:
         catalogs = [default_catalog]
@@ -34,7 +27,7 @@ def get_device_catalogs(
 
         grouped_by_catalog = defaultdict(list)
         for item in groups:
-            grouped_by_catalog[item['catalog']].append(item)
+            grouped_by_catalog[item["catalog"]].append(item)
 
         multiple_result = dict(grouped_by_catalog)
 
@@ -44,18 +37,16 @@ def get_device_catalogs(
                 catalogs_to_remove.append(catalog)
 
         for group in groups:
-            if group["catalog"] is not None:
-                if (group["catalog"] in multiple_result):
-                    # get group names
-                    group_names = [item["name"] for item in multiple_result[group["catalog"]]]
-                    if group["name"] not in group_names:
-                        device_manifest.catalogs.remove(group["catalog"])
-                        catalogs_to_remove.append(group["catalog"])
-                elif (
-                    group["name"] not in device_manifest.included_manifests
-                    and group["catalog"] in device_manifest.catalogs
-                ):
+            if group["catalog"] is None:
+                continue
+            if group["catalog"] in multiple_result:
+                # get group names
+                group_names = [item["name"] for item in multiple_result[group["catalog"]]]
+                if group["name"] not in group_names:
                     device_manifest.catalogs.remove(group["catalog"])
                     catalogs_to_remove.append(group["catalog"])
+            elif group["name"] not in device_manifest.included_manifests and group["catalog"] in device_manifest.catalogs:
+                device_manifest.catalogs.remove(group["catalog"])
+                catalogs_to_remove.append(group["catalog"])
 
         return catalogs_to_remove

--- a/munki_manifest_generator/graph/concurrent_batch.py
+++ b/munki_manifest_generator/graph/concurrent_batch.py
@@ -1,0 +1,188 @@
+import json
+import concurrent.futures
+import uuid
+import time
+import urllib.parse
+import logging
+import threading
+
+from munki_manifest_generator.graph.make_api_request import make_api_request_Post
+from munki_manifest_generator.logger import logger
+
+
+batches = []
+
+
+def get_data(ids: list, url: str, extra_url: str, batch_type: str, token: dict, method: str) -> dict:
+    """Create a batch request to the Graph API"""
+
+    # Remove empty strings and the default GUID from the list of ids
+    unique_ids = set(ids) - {"00000000-0000-0000-0000-000000000000"} - {""}
+    # Create a list of dictionaries with the id, method and url of the request
+    if batch_type == "deviceId":
+        requests = [{"id": i, "method": method, "url": f"{url}?$filter=deviceId eq '{i}'"} for i in unique_ids]
+    elif batch_type == "upn":
+        requests = [
+            {
+                "id": f"{i}_{int(time.time() * 1000)}",
+                "method": method,
+                "url": f"{url}?$filter=userPrincipalName eq '{urllib.parse.quote(i)}'",
+            }
+            for i in unique_ids
+            if i
+        ]
+    elif batch_type == "user" or batch_type == "device":
+        requests = [
+            {
+                "id": i,
+                "method": method,
+                "url": url + i + extra_url,
+                "headers": {"ConsistencyLevel": "eventual"},
+            }
+            for i in unique_ids
+        ]
+    # If no batch type is specified, the ids are already in the correct format
+    else:
+        requests = [{"id": i, "method": method, "url": url + i + extra_url} for i in unique_ids]
+
+    # Create a dictionary with the key "requests" and the value being the list of dictionaries
+    batches.append(requests)
+    json_data = json.dumps({"requests": requests})
+    # Make the request to the Graph API
+    return make_api_request_Post("https://graph.microsoft.com/beta/$batch", token, jdata=json_data)
+
+
+def batch_request(
+    data: list,
+    url: str,
+    extra_url: str,
+    batch_type: str,
+    token: dict,
+    method="GET",
+    retry_pool=None,
+) -> list:
+    """Create concurrent batch requests to the Graph API"""
+
+    # If the type is "device" or "user", get the ids from the data
+    get_ids = False
+    if batch_type != "device" and batch_type != "user":
+        pass
+    else:
+        get_ids = True
+
+    if get_ids:
+        ids = [
+            val.get("id")  # Append the value associated with the "id" key to the ids list
+            for l in data  # For each dictionary in the list of dictionaries
+            for val in l["value"]  # For each dictionary in the "value" list of that dictionary
+            if "id" in val.keys() and val.get("id") is not None  # If the dictionary contains a key "id"
+        ]  # And if the value associated with the "id" key is not None
+
+    # If the type is not "device" or "user", the ids are already in the correct format
+    else:
+        ids = data
+
+    # Set the object type
+    if batch_type == "device":
+        object_type = "deviceId"
+    elif batch_type == "user":
+        object_type = "userPrincipalName"
+
+    # Create a dictionary with the ids as keys and the object type as values
+    if get_ids:
+        id_to_object = {}
+        for d in data:
+            for val in d.get("value", []):
+                if "id" in val and val["id"] is not None:
+                    id_to_object[val["id"]] = val.get(object_type, "")
+
+    responses = []
+    retry_pool = []
+    wait_time = 0
+    batch_count = 20
+    batch_list = [ids[i : i + batch_count] for i in range(0, len(ids), batch_count)]
+    batch_id = 0
+
+    def get_response_body(response) -> None:
+        """Get the response body from the batch request"""
+
+        # Make the retry_pool variable
+        nonlocal retry_pool
+        # Make the wait_time variable
+        nonlocal wait_time
+
+        for r in response:
+            wait_time = 0  # Reset the wait time
+
+            if r["body"].get("value") is not None:
+                for val in r["body"]["value"]:
+                    if val.get("accountEnabled") is False:
+                        logger.info(f"Skipping disabled account: {val.get('userPrincipalName')}")
+                        continue
+
+            # if the status code is 200, append the response body to the responses list
+            if r["status"] == 200:
+                if get_ids:
+                    r["body"][object_type] = id_to_object.get(r["id"], "")
+
+                responses.append(r["body"])
+            # if the status code is 429, append the id to the retry pool
+            elif r["status"] == 429 or r["status"] == 503:
+                if get_ids:
+                    # Append the id and the object type to the retry pool
+                    batch = {"value": [{"id": r["id"], object_type: id_to_object.get(r["id"], "")}]}
+                    if retry_pool is not None:
+                        retry_pool.append(batch)
+                else:
+                    # Append the id to the retry pool
+                    batch = {"value": [{"id": r["id"]}]}
+                    if retry_pool is not None:
+                        retry_pool.append(batch)
+                # Get the wait time from the response headers
+                wait_time = int(r["headers"].get("Retry-After", 0))
+            # Else, log the error
+            else:
+                if logger.isEnabledFor(logging.DEBUG):
+                    failed_batch_request = next(
+                        (i for i in batches for j in i if any(v == r["id"] for k, v in j.items())),
+                        None,
+                    )
+
+                    if failed_batch_request:
+                        logger.debug("Failed batch request: %s" % failed_batch_request)
+                logger.error(f'Request failed with status code {r["status"]} for {r["id"]}')
+
+    # Create a thread pool and submit the requests
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        future_to_id = {
+            executor.submit(get_data, batch, url, extra_url, batch_type, token, method): batch_id for batch in batch_list
+        }
+        # Get the responses from the requests
+        for future in concurrent.futures.as_completed(future_to_id):
+            # batch_id = future_to_id[future]
+            try:
+                response = future.result()["responses"]
+                get_response_body(response)
+
+            except Exception as exc:
+                logger.warning(f"Exception {exc} for batch {batch_id} from thread {threading.current_thread().name}")
+
+            batch_id += 1
+
+    # If the retry pool is not empty, make another batch request
+    if retry_pool is not None and retry_pool:  # check if the "value" key of retry_pool is not empty
+        retry_batch = retry_pool
+        if wait_time > 0:
+            logger.info(f"Waiting {wait_time} seconds before retrying batch request")
+            time.sleep(wait_time)
+        responses += batch_request(
+            retry_batch,
+            url,
+            extra_url,
+            batch_type,
+            token,
+            method,
+            retry_pool=retry_pool,
+        )
+
+    return responses

--- a/munki_manifest_generator/graph/get_authentication_token.py
+++ b/munki_manifest_generator/graph/get_authentication_token.py
@@ -7,15 +7,20 @@ This module is used to get the access token for the tenant.
 import os
 import json
 
-from munki_manifest_generator.graph.obtain_access_token import obtain_accesstoken_app, obtain_accesstoken_cert, obtain_accesstoken_interactive
+from munki_manifest_generator.graph.obtain_access_token import (
+    obtain_accesstoken_app,
+    obtain_accesstoken_cert,
+    obtain_accesstoken_interactive,
+)
 
-def getAuth(app, certauth, interactiveauth):
+
+def getAuth(app: bool, certauth: bool, interactiveauth: bool) -> dict:
     """
     This function authenticates to MS Graph and returns the access token.
 
-    :param mode: The mode used when using this tool
-    :param localauth: Path to dict with keys to authenticate
-    :param tenant: Which tenant to authenticate to, PROD or DEV
+    :param app: Boolean to indicate if the app authentication method should be used
+    :param certauth: Boolean to indicate if the certificate authentication method should be used
+    :param interactiveauth: Boolean to indicate if the interactive authentication method should be used
     :return: The access token
     """
 

--- a/munki_manifest_generator/graph/get_user_group_membership.py
+++ b/munki_manifest_generator/graph/get_user_group_membership.py
@@ -1,59 +1,67 @@
 #!/usr/bin/env python3
 
+import logging
+
+from munki_manifest_generator.logger import logger
+
 """
 This module is used to get the user group membership and update included manifests.
 """
 
-from munki_manifest_generator.graph.make_api_request import make_api_request
 
 ENDPOINT = "https://graph.microsoft.com/v1.0/users"
 
 
-def get_user_group_membership(token, upn, groups, current_manifests, device_manifest):
+def get_user_group_membership(responses, groups, current_manifests, device_manifest):
     """Returns a list of group names the user is a member of and updates the included manifests."""
 
-    aad_user_object_id = None
-    q_param_user = {"$filter": "userPrincipalName eq '%s'" % upn}
-    user_object = make_api_request(ENDPOINT, token, q_param_user)
+    user = device_manifest.__dict__["user"]
+    serial_number = device_manifest.__dict__["serialnumber"]
+    memberOf = [val for val in responses if user in val["userPrincipalName"] for val in val["value"]]
 
-    for id in user_object["value"]:
-        object_id = id["id"]
-        aad_user_object_id = object_id
-    q_param_group = {"$select": "id,displayName"}
-
-    # If Azure AD user id is none, skip getting groups
-    if aad_user_object_id is None:
-        print("AAD User ID is null, skipping user group memberships")
-
-    else:
-        memberOf = make_api_request(
-            ENDPOINT + "/" + aad_user_object_id + "/transitiveMemberOf", token, q_param_group
-        )
-
+    if memberOf:
         user_groups = []
         user_groups_name = []
 
-        for group_id in memberOf["value"]:
+        for group_id in memberOf:
             id = group_id["id"]
             user_groups.append(id)
             user_groups_name.append(group_id["displayName"])
+
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "[%s] User found in groups: %s",
+                serial_number,
+                ", ".join(user_groups_name),
+            )
+            logger.debug(
+                "[%s] Groups from JSON or list: %s",
+                serial_number,
+                str(groups),
+            )
 
         for group in groups:
             if group["type"] == "user":
                 if group["id"] in user_groups:
                     if group["name"] in current_manifests:
                         if group["name"] not in device_manifest.included_manifests:
-                            print(
-                                "User found in group for "
-                                + group["name"]
-                                + ", adding included manifest for group"
+                            logger.info(
+                                "[%s] User found in group for %s, adding included manifest for group",
+                                serial_number,
+                                group["name"],
                             )
                             device_manifest.included_manifests.append(group["name"])
                     else:
-                        print(
-                            "User found in group for "
-                            + (group["name"])
-                            + " but manifest does not exist, skipping"
+                        logger.info(
+                            "[%s] User found in group for %s but manifest does not exist, skipping",
+                            serial_number,
+                            group["name"],
                         )
 
         return user_groups_name
+
+    else:
+        logger.warning(
+            "[%s] User not found in any groups",
+            serial_number,
+        )

--- a/munki_manifest_generator/logger.py
+++ b/munki_manifest_generator/logger.py
@@ -1,0 +1,63 @@
+import logging
+import sys
+import threading
+
+from logging.handlers import RotatingFileHandler
+
+
+class CustomFormatter(logging.Formatter):
+    """Logging colored formatter, adapted from https://stackoverflow.com/a/56944256/3638629"""
+
+    grey = "\x1b[38;5;244m"
+    cyan = "\x1b[36m"
+    yellow = "\x1b[38;5;226m"
+    red = "\x1b[38;5;9m"
+    bold_red = "\x1b[31;1m"
+    reset = "\x1b[0m"
+
+    def __init__(self, fmt, error_fmt):
+        super().__init__()
+        self.fmt = fmt
+        self.error_fmt = error_fmt
+        self.FORMATS = {
+            logging.DEBUG: self.error_fmt,
+            logging.INFO: self.fmt,
+            logging.WARNING: self.error_fmt,
+            logging.ERROR: self.error_fmt,
+            logging.CRITICAL: self.error_fmt,
+        }
+
+    def format(self, record):
+        log_fmt = self.FORMATS.get(record.levelno)
+        formatter = logging.Formatter(log_fmt)
+        return formatter.format(record)
+
+
+class CustomLogger(logging.Logger):
+    """Custom logger class with multiple destinations"""
+
+    def __init__(self, name, log_file=None):
+        super().__init__(name)
+        self.lock = threading.Lock()  # create a lock object
+        handler = logging.StreamHandler(sys.stdout)
+        info_fmt = "%(asctime)s [%(levelname)s] %(message)s"
+        error_fmt = "%(asctime)s [%(levelname)s] %(message)s (%(filename)s:%(lineno)d:%(funcName)s)"
+        handler.setFormatter(CustomFormatter(fmt=info_fmt, error_fmt=error_fmt))
+        handler.setLevel(logging.INFO)
+        self.addHandler(handler)
+        if log_file:
+            file_handler = RotatingFileHandler(
+                log_file, mode="a", maxBytes=5 * 1024 * 1024, backupCount=2, encoding=None, delay=0
+            )
+            file_handler.setLevel(logging.INFO)
+            file_handler.setFormatter(CustomFormatter(fmt=info_fmt, error_fmt=error_fmt))
+            self.addHandler(file_handler)
+        self.handler = handler
+
+    def handle(self, record):
+        with self.lock:  # acquire the lock
+            super().handle(record)
+            self.handler.flush()
+
+
+logger = CustomLogger(__name__, log_file="mmg.log")

--- a/munki_manifest_generator/main.py
+++ b/munki_manifest_generator/main.py
@@ -6,9 +6,12 @@ This module creates and updates manifests for macOS devices in Intune.
 
 import os
 import json
+import time
 import argparse
+import threading
 
 from operator import itemgetter
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from munki_manifest_generator.manifest import Manifest
 from munki_manifest_generator.graph.get_authentication_token import getAuth
 from munki_manifest_generator.graph.make_api_request import make_api_request
@@ -19,25 +22,34 @@ from munki_manifest_generator.graph.get_user_group_membership import (
     get_user_group_membership,
 )
 from munki_manifest_generator.get_device_catalogs import get_device_catalogs
+from munki_manifest_generator.graph.concurrent_batch import batch_request
+
+from munki_manifest_generator.logger import logger
 from munki_manifest_generator.azstorage.az_storage_actions import (
     get_current_manifest_blobs,
     delete_manifest_blob,
     update_manifest_blob,
+    update_current_upn,
     get_current_device_manifest,
     create_manifest_blob,
 )
 
 
 def main(**kwargs):
+    # Start timer
+    startTime = time.time()
 
+    # Set variables to None
     j = None
-    l = None
+    g = None
     s = None
     t = None
     d = None
     c = None
     i = None
+    l = None
 
+    # If no kwargs are passed, parse arguments
     if not kwargs:
         argparser = argparse.ArgumentParser()
         argparser.add_argument(
@@ -51,7 +63,7 @@ def main(**kwargs):
             help="Path to JSON file containing AzureAD groups specifying manifests devices should be in.",
         )
         argparser.add_argument(
-            "-l",
+            "-g",
             "--group_list",
             help="List of dicts containing AzureAD groups specifying manifests devices should be in.",
         )
@@ -62,14 +74,14 @@ def main(**kwargs):
         )
         argparser.add_argument(
             "-t",
-           "--test",
+            "--test",
             help="Enable testing, no changes will be made to manifests on Azure Storage.",
             action="store_true",
         )
         argparser.add_argument(
-            "-d", "--default_catalog", 
-            help="Default catalog for all devices. If not specified, the default catalog will be 'Production'."
-            
+            "-d",
+            "--default_catalog",
+            help="Default catalog for all devices. If not specified, the default catalog will be 'Production'.",
         )
         argparser.add_argument(
             "-c",
@@ -83,51 +95,93 @@ def main(**kwargs):
             help="When using interactive auth, the following ENV variables is required: TENANT_NAME, CLIENT_ID",
             action="store_true",
         )
+        argparser.add_argument(
+            "-v",
+            "--version",
+            action="version",
+            version="%(prog)s (version {version})".format(version="0.0.1"),
+        )
+        argparser.add_argument(
+            "-l",
+            "--log",
+            help="Log level, default is INFO",
+            default="INFO",
+            choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        )
 
         args = argparser.parse_args()
 
-        if args.test:
-            print(
-                "*****Testing mode enabled, no changes will be made to manifests on Azure Storage*****"
-            )
+        if args.log:
+            for handler in logger.handlers:
+                handler.setLevel(args.log.upper())
 
+        if args.test:
+            logger.info("*****Testing mode enabled, no changes will be made to manifests on Azure Storage*****")
+
+    # Else, set variables to kwargs
     else:
         s = kwargs.get("serial_number")
         j = kwargs.get("json_file")
-        l = kwargs.get("group_list")
+        g = kwargs.get("group_list")
         sm = kwargs.get("safe_manifest")
         t = kwargs.get("test")
         d = kwargs.get("default_catalog")
         c = kwargs.get("certauth")
         i = kwargs.get("interactiveauth")
+        l = kwargs.get("log")
 
+        # If log level is passed, set it
+        if l:
+            choices = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+            if l in choices:
+                for handler in logger.handlers:
+                    handler.setLevel(l.upper())
+            else:
+                raise Exception("Invalid log level, choose from: DEBUG, INFO, WARNING, ERROR, CRITICAL")
+
+        # If testing is enabled, log it
         if t:
-            print(
-                "*****Testing mode enabled, no changes will be made to manifests on Azure Storage*****"
-            )
+            logger.info("*****Testing mode enabled, no changes will be made to manifests on Azure Storage*****")
 
-
-    def run(json_file, group_list, serial_number, SAFE_MANIFEST, TEST, DEFAULT_CATALOG, CERTAUTH, INTERACTIVEAUTH):
-
-        if not all([os.environ.get("CONTAINER_NAME"), os.environ.get("AZURE_STORAGE_CONNECTION_STRING")]):
+    def run(
+        json_file,
+        group_list,
+        serial_number,
+        SAFE_MANIFEST,
+        TEST,
+        DEFAULT_CATALOG,
+        CERTAUTH,
+        INTERACTIVEAUTH,
+    ):
+        # Check if required environment variables are set
+        if not all(
+            [
+                os.environ.get("CONTAINER_NAME"),
+                os.environ.get("AZURE_STORAGE_CONNECTION_STRING"),
+            ]
+        ):
             raise Exception("Missing required environment variables, stopping...")
+
+        # Set variables
         CONTAINER_NAME = os.environ.get("CONTAINER_NAME")
         CONNECTION_STRING = os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
         ENDPOINT = "https://graph.microsoft.com/v1.0/deviceManagement/managedDevices"
-        if not CERTAUTH and not INTERACTIVEAUTH:
-            APP = True
-        else:
-            APP = False
-        TOKEN = getAuth(APP, CERTAUTH, INTERACTIVEAUTH)
-        CURRENT_MANIFESTS = get_current_manifest_blobs(
-            CONNECTION_STRING, CONTAINER_NAME
-        )
 
+        # If certificate or interactive auth is enabled, set APP to False
+        if CERTAUTH or INTERACTIVEAUTH:
+            APP = False
+        else:
+            APP = True
+
+        # Get authentication token
+        TOKEN = getAuth(APP, CERTAUTH, INTERACTIVEAUTH)
+        # Get current manifests from Azure Storage
+        CURRENT_MANIFESTS = get_current_manifest_blobs(CONNECTION_STRING, CONTAINER_NAME)
+        # If custom default catalog is passed, set it
         if DEFAULT_CATALOG:
             DEFAULT_CATALOG = DEFAULT_CATALOG
         else:
             DEFAULT_CATALOG = "Production"
-
         # If a serial number is passed, create or update a manifest for that device
         if serial_number:
             Q_PARAM = {"$filter": "serialNumber eq '%s'" % serial_number}
@@ -135,15 +189,13 @@ def main(**kwargs):
 
             # If two objects are found, get the latest enrolled device
             if DEVICES["@odata.count"] > 1:
-                latest_enrolled = max(
-                    DEVICES["value"], key=lambda x: x["enrolledDateTime"]
-                )
+                latest_enrolled = max(DEVICES["value"], key=lambda x: x["enrolledDateTime"])
                 DEVICES["value"] = [latest_enrolled]
                 DEVICES["@odata.count"] = 1
 
             # If no device is returned, stop script
             if DEVICES["@odata.count"] == 0:
-                print(f"Device with serial {serial_number} not found, stopping...")
+                logger.error(f"Device with serial {serial_number} not found, stopping...")
                 quit()
 
         # Else, create or update manifests for all devices
@@ -151,25 +203,48 @@ def main(**kwargs):
             Q_PARAM = {"$filter": "operatingSystem eq 'macOS'"}
             DEVICES = make_api_request(ENDPOINT, TOKEN, Q_PARAM)
             # Check if there are duplicate entries for a device
-            for d in DEVICES['value']:
-                for index, value in enumerate(DEVICES['value']):
-                    if d['serialNumber'] == value['serialNumber']:
+            for d in DEVICES["value"]:
+                for index, value in enumerate(DEVICES["value"]):
+                    if d["serialNumber"] == value["serialNumber"]:
                         # If the device is enrolled more than once, get the latest enrolled device
-                        if d['enrolledDateTime'] > value['enrolledDateTime']:
+                        if d["enrolledDateTime"] > value["enrolledDateTime"]:
                             # Remove the older device from the list
-                            DEVICES['value'].remove(DEVICES['value'][index])
+                            DEVICES["value"].remove(DEVICES["value"][index])
 
-            print("-" * 90)
-            print(f"Found {len(CURRENT_MANIFESTS)} current manifests")
-            print(f"Found {DEVICES['@odata.count']} devices")
+            import re
+            def contains_random_uuid(upn):
+                # Construct a regular expression pattern that matches the specified format
+                pattern = re.compile(r"[A-Za-z]+([0-9]+([A-Za-z]+[0-9]+)+).*@.*", re.IGNORECASE)
 
-        SERIAL_NUMBERS = [
-            val
-            for d in DEVICES["value"]
-            for key, val in d.items()
-            if "serialNumber" in key
-            if val is not None
+                # Use the re module to search for the pattern in the input string
+                match = re.search(pattern, upn)
+
+                # If a match is found, return True; otherwise, return False
+                if match:
+                    return True
+                else:
+                    return False
+
+            # Remove devices that have a UPN that contains a random UUID
+            DEVICES["value"] = [d for d in DEVICES["value"] for key, val in d.items() if "userPrincipalName" in key if val is not None if not contains_random_uuid(val)]
+
+            logger.info("-" * 90)
+            logger.info(f"Found {len(CURRENT_MANIFESTS)} current manifests")
+            logger.info(f'Found {len(DEVICES["value"])} devices')
+
+
+
+
+            logger.info("-" * 90)
+
+        # Get serial numbers, AAD device IDs, and UPNs for all devices
+        SERIAL_NUMBERS = [val for d in DEVICES["value"] for key, val in d.items() if "serialNumber" in key if val is not None]
+
+        AAD_DEVICE_IDS = [
+            val for d in DEVICES["value"] for key, val in d.items() if "azureADDeviceId" in key if val is not None
         ]
+
+        UPNs = [val for d in DEVICES["value"] for key, val in d.items() if "userPrincipalName" in key if val is not None]
 
         # Get list of group manifests from json file or list
         if json_file:
@@ -180,24 +255,50 @@ def main(**kwargs):
         else:
             raise Exception("No JSON file or list provided")
 
+        # Batch get group memberships for all devices and users
+        group_search = []
+        for group in GROUPS:
+            group_search.append('"displayName:%s"' % group["name"])
+
+        group_search_query = f'({" OR ".join(group_search)})'
+
+        if "device" in map(itemgetter("type"), GROUPS):
+            # Batch get ids for all devices and users
+            device_id_responses = batch_request(AAD_DEVICE_IDS, "devices", "", "deviceId", TOKEN)
+            device_group_responses = batch_request(
+                device_id_responses, "devices/", "/transitiveMemberOf?$search=%s" % group_search_query, "device", TOKEN
+            )
+
+        if "user" in map(itemgetter("type"), GROUPS):
+            device_upn_responses = batch_request(UPNs, "users", "", "upn", TOKEN)
+            user_group_responses = batch_request(
+                device_upn_responses,
+                "users/",
+                "/transitiveMemberOf?$select=id,displayName&$search=%s" % group_search_query,
+                "user",
+                TOKEN,
+            )
+
         # If not passing a serial number, delete manifest for device if it is not in Intune
         if not serial_number:
             delete_manifest_blob(
-                CONNECTION_STRING, CONTAINER_NAME, GROUPS, SERIAL_NUMBERS, SAFE_MANIFEST, TEST
+                CONNECTION_STRING,
+                CONTAINER_NAME,
+                GROUPS,
+                SERIAL_NUMBERS,
+                SAFE_MANIFEST,
+                TEST,
+                CURRENT_MANIFESTS,
             )
 
-        for device in DEVICES["value"]:
+        def process_device(device):
+            """Process each device"""
 
-            if not device["serialNumber"]:
-                continue
-
+            lock = threading.Lock()
             group_membership = []
             # If a manifest exists for the device, update it.
             if device["serialNumber"] in CURRENT_MANIFESTS:
-                
-                print("{0:-^{1}}".format(device["serialNumber"], 90))
-                print("Manifest found, checking for updates")
-
+                logger.debug("[%s] Manifest found, checking for updates..." % device["serialNumber"])
                 current_device_manifest = get_current_device_manifest(
                     CONNECTION_STRING, CONTAINER_NAME, device["serialNumber"]
                 )
@@ -210,29 +311,41 @@ def main(**kwargs):
                     user=current_device_manifest["user"],
                 )
 
+                if device_manifest.user != device["userPrincipalName"]:
+                    update_current_upn(
+                        CONNECTION_STRING,
+                        CONTAINER_NAME,
+                        device_manifest.serialnumber,
+                        device["userPrincipalName"],
+                        device_manifest.user,
+                        TEST,
+                    )
+                    device_manifest.user = device["userPrincipalName"]
+
                 # If device groups are in the JSON or list, get the groups the device is in
                 if "device" in map(itemgetter("type"), GROUPS):
                     device_groups = get_device_group_membership(
-                        TOKEN,
+                        device_group_responses,
                         device["azureADDeviceId"],
                         GROUPS,
                         CURRENT_MANIFESTS,
                         device_manifest,
                     )
                     if device_groups:
-                        group_membership += device_groups
+                        with lock:
+                            group_membership += device_groups
 
                 # If user groups are in the JSON or list, get the groups the device's user is in
                 if "user" in map(itemgetter("type"), GROUPS):
                     user_groups = get_user_group_membership(
-                        TOKEN,
-                        device["userPrincipalName"],
+                        user_group_responses,
                         GROUPS,
                         CURRENT_MANIFESTS,
                         device_manifest,
                     )
                     if user_groups:
-                        group_membership += user_groups
+                        with lock:
+                            group_membership += user_groups
 
                 update_manifest_blob(
                     CONNECTION_STRING,
@@ -242,14 +355,13 @@ def main(**kwargs):
                     group_membership,
                     GROUPS,
                     TEST,
-                    DEFAULT_CATALOG
+                    DEFAULT_CATALOG,
+                    CURRENT_MANIFESTS,  # noqa: F821
                 )
 
             # If no manifest exists for the device, create one.
             else:
-                print("{0:-^{1}}".format(device["serialNumber"], 90))
-                print("Manifest not found, creating")
-
+                logger.info("[%s] No manifest found, creating..." % device["serialNumber"])
                 device_manifest = Manifest(
                     catalogs=[DEFAULT_CATALOG],
                     included_manifests=["site_default"],
@@ -261,43 +373,61 @@ def main(**kwargs):
                 # If device groups are in the JSON or list, get the groups the device is in
                 if "device" in map(itemgetter("type"), GROUPS):
                     device_groups = get_device_group_membership(
-                        TOKEN,
+                        device_group_responses,
                         device["azureADDeviceId"],
                         GROUPS,
                         CURRENT_MANIFESTS,
                         device_manifest,
                     )
                     if device_groups:
-                        group_membership += device_groups
+                        with lock:
+                            group_membership += device_groups
 
                 # If user groups are in the JSON or list, get the groups the device's user is in
                 if "user" in map(itemgetter("type"), GROUPS):
                     user_groups = get_user_group_membership(
-                        TOKEN,
-                        device["userPrincipalName"],
+                        user_group_responses,
                         GROUPS,
                         CURRENT_MANIFESTS,
                         device_manifest,
                     )
                     if user_groups:
-                        group_membership += user_groups
+                        with lock:
+                            group_membership += user_groups
 
-                device_manifest.catalogs = get_device_catalogs(
-                    GROUPS, device_manifest, DEFAULT_CATALOG, add_catalogs=True
-                )
+                device_manifest.catalogs = get_device_catalogs(GROUPS, device_manifest, DEFAULT_CATALOG, add_catalogs=True)
 
                 create_manifest_blob(
                     CONNECTION_STRING,
                     CONTAINER_NAME,
                     device["serialNumber"],
                     device_manifest,
-                    TEST
+                    TEST,
                 )
 
+        with ThreadPoolExecutor() as executor:
+            futures = [executor.submit(process_device, device) for device in DEVICES["value"] if device["serialNumber"]]
+            for future in as_completed(futures):
+                try:
+                    result = future.result()
+                except Exception as e:
+                    logger.error(f"Exception: {e}")
+
     if not kwargs:
-        run(args.json, args.group_list, args.serial_number, args.safe_manifest, args.test, args.default_catalog, args.certauth, args.interactiveauth)
+        run(
+            args.json,
+            args.group_list,
+            args.serial_number,
+            args.safe_manifest,
+            args.test,
+            args.default_catalog,
+            args.certauth,
+            args.interactiveauth,
+        )
     else:
-        run(j, l, s, sm, t, d, c, i)
+        run(j, g, s, sm, t, d, c, i)
+
+    logger.debug("Finished in {0} seconds.".format(time.time() - startTime))
 
 
 if __name__ == "__main__":

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = Munki-Manifest-Generator
-version = 1.1.2
+version = 1.2.0
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to create and update Munki manifests for devices managed in Intune
@@ -15,11 +15,12 @@ classifiers =
     Operating System :: OS Independent
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     msal >= 1.20.0
-    msrest>=0.6.21
-    azure-storage-blob >= 12.13.1
+    msrest>=0.7.1
+    azure-storage-blob >= 12.15.0
+    retrying >= 1.3.4
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This pull request adds concurrent batching functionality to the tool to speed up run time when targeting large numbers of devices.

- Graph calls to get devices and users groups is batched concurrently
- Per device operations is run concurrently
- Prints is changed to logging module for better output
    - Configurable by setting `--log` to either `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. Default is `INFO`
- `-l` for `--group_list` is changed to `-g` as `-l` has been assigned to `--log` instead
- Required packages has had their versions updated and additional requirements has been added
     - Python version: 3.6 -> 3.7 and above
     - merest: 0.6.21 -> 0.7.1
     - azure_storage_blob: 12.13.1 -> 12.15.0
     - retrying: **NEW**
 