### PR TITLE
v1.2.1

### DIFF
--- a/munki_manifest_generator/get_device_catalogs.py
+++ b/munki_manifest_generator/get_device_catalogs.py
@@ -7,18 +7,31 @@ This module is used to get the catalogs that should be added or removed from a d
 from collections import defaultdict
 
 
-def get_device_catalogs(groups, device_manifest, default_catalog, add_catalogs=False, remove_catalogs=False) -> list:
+def get_device_catalogs(
+    groups, device_manifest, default_catalog, add_catalogs=False, remove_catalogs=False
+) -> list:
     """Get the catalogs that should be added or removed from a device."""
 
-    GROUP_CATALOGS = [val for list in groups for key, val in list.items() if "catalog" in key if val is not None]
+    GROUP_CATALOGS = [
+        val
+        for list in groups
+        for key, val in list.items()
+        if "catalog" in key
+        if val is not None
+    ]
 
     if add_catalogs:
         catalogs = [default_catalog]
 
         for group in groups:
             if group["catalog"] is not None:
-                if group["name"] in device_manifest.included_manifests:
+                if (
+                    group["name"] in device_manifest.included_manifests
+                    and group["catalog"] not in catalogs
+                ):
                     catalogs.insert(0, group["catalog"])
+
+        catalogs = list(set(catalogs))
 
         return catalogs
 
@@ -41,12 +54,19 @@ def get_device_catalogs(groups, device_manifest, default_catalog, add_catalogs=F
                 continue
             if group["catalog"] in multiple_result:
                 # get group names
-                group_names = [item["name"] for item in multiple_result[group["catalog"]]]
+                group_names = [
+                    item["name"] for item in multiple_result[group["catalog"]]
+                ]
                 if group["name"] not in group_names:
                     device_manifest.catalogs.remove(group["catalog"])
                     catalogs_to_remove.append(group["catalog"])
-            elif group["name"] not in device_manifest.included_manifests and group["catalog"] in device_manifest.catalogs:
+            elif (
+                group["name"] not in device_manifest.included_manifests
+                and group["catalog"] in device_manifest.catalogs
+            ):
                 device_manifest.catalogs.remove(group["catalog"])
                 catalogs_to_remove.append(group["catalog"])
+
+        catalogs_to_remove = list(set(catalogs_to_remove))
 
         return catalogs_to_remove

--- a/munki_manifest_generator/graph/make_api_request.py
+++ b/munki_manifest_generator/graph/make_api_request.py
@@ -9,7 +9,11 @@ import json
 
 from retrying import retry
 
-
+@retry(
+    wait_exponential_multiplier=1000,
+    wait_exponential_max=10000,
+    stop_max_attempt_number=5,
+)
 def make_api_request(endpoint, token, q_param=None):
     """Makes a get request and returns the response."""
     # Create a valid header using the provided access token

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = Munki-Manifest-Generator
-version = 1.2.1.beta1
+version = 1.2.1
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to create and update Munki manifests for devices managed in Intune

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = Munki-Manifest-Generator
-version = 1.2.0
+version = 1.2.1.beta1
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to create and update Munki manifests for devices managed in Intune


### PR DESCRIPTION
### Changed
- Retrying has been added to get requests
### Fixed
- If a device is part of multiple included manifests that has the same catalog, the catalog is now only added once instead of multiple times